### PR TITLE
fix: move closeEditorsToTheLeft as custom command

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "title": "Close Diff Editors"
       },
       {
-        "command": "workbench.action.closeEditorsToTheLeft",
+        "command": "close-tabs.close-left",
         "title": "Close to the Left",
         "enablement": "!activeEditorIsFirstInGroup"
       }
@@ -58,7 +58,7 @@
           "when": "config.closeTabs.showCloseDiffEditors"
         },
         {
-          "command": "workbench.action.closeEditorsToTheLeft",
+          "command": "close-tabs.close-left",
           "group": "1_close@30",
           "when": "config.closeTabs.showCloseToTheLeft"
         }

--- a/src/commands/closeLeft.ts
+++ b/src/commands/closeLeft.ts
@@ -1,0 +1,7 @@
+import * as vscode from "vscode";
+
+export const closeLeft = async () => {
+  await vscode.commands.executeCommand(
+    "workbench.action.closeEditorsToTheLeft"
+  );
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { closeUnchanged } from "./commands/closeUnchanged";
 import { Change, GitExtension, Repository } from "./git";
+import { closeLeft } from "./commands/closeLeft";
 
 export function activate(context: vscode.ExtensionContext) {
   const closeUnchangedCmd = vscode.commands.registerCommand(
@@ -8,5 +9,11 @@ export function activate(context: vscode.ExtensionContext) {
     closeUnchanged
   );
 
+  const closeLeftCmd = vscode.commands.registerCommand(
+    "close-tabs.close-left",
+    closeLeft
+  );
+
   context.subscriptions.push(closeUnchangedCmd);
+  context.subscriptions.push(closeLeftCmd);
 }


### PR DESCRIPTION
Temporary fix for #15 

This enables again the command but it works from the currently active tab, not from the tab where the used clicked and opened the context menu.

I'm still trying to figure out how to select that tab, but let's push this patch for the moment.